### PR TITLE
Add station swap functionality (Issue#2)

### DIFF
--- a/frontend/app/SearchForm.tsx
+++ b/frontend/app/SearchForm.tsx
@@ -139,6 +139,8 @@ export default function SearchForm() {
     if (e.key === 'Enter') submitSearch();
   };
 
+  const swapStations = () => (setFrom(to), setTo(from));
+
   return (
     <form
       onSubmit={(e) => e.preventDefault()}
@@ -163,11 +165,19 @@ export default function SearchForm() {
           />
         </div>
 
-        {/* 矢印 */}
-        <div className="hidden sm:flex items-center justify-center text-slate-300">
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
+        {/* 入れ替えボタン */}
+        <div className="flex sm:flex items-center justify-center">
+          <button
+            type="button"
+            onClick={swapStations}
+            disabled={isPending}
+            className="flex items-center justify-center w-8 h-8 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 hover:text-slate-700 transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
+            aria-label="出発地と目的地を入れ替え"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+          </button>
         </div>
 
         {/* 目的地 */}


### PR DESCRIPTION
# 🔄 駅名入れ替え機能の追加

Issue#2の対応として、出発地と到着地を簡単に入れ替えできるUI機能を実装しました。

## 📋 実装内容

- **スワップボタンの追加**: 出発地と到着地の間に直感的な入れ替えボタンを配置
- **UIデザイン**: 双方向矢印アイコンを使用したレスポンシブ対応ボタン
- **機能実装**: ワンクリックで出発地と到着地の値を瞬時に交換
- **最適化**: temp変数不要のコンマオペレーター活用で1行実装

## 🎯 ユーザーエクスペリエンス向上

- 往復の経路検索が簡単に
- 入力済みの駅名を再利用可能
- アクセシビリティ対応済み（aria-label付き）
- 検索中は無効化で安全性確保

## 🧪 動作確認

- [x] 駅名入力 → スワップ → 正常に交換
- [x] スワップ後の検索機能正常動作
- [x] レスポンシブデザイン対応
- [x] UI/UXの一貫性維持

Co-authored-by: openhands <openhands@all-hands.dev>

@kikudesuyo can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8df5e58b-a042-4339-bc2f-3df3c94d2534)