### PR TITLE
feat: 検索候補と経路詳細を表示

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,7 @@
 .PHONY: init build dev lint
 
 GO111MODULE=on
-PROJECT=whichway-494614
+PROJECT=point-hub-496713
 
 init:
 	go mod download
@@ -25,7 +25,7 @@ deploy:
 	make __deploy project=${PROJECT}
 
 __deploy:
-	gcloud functions deploy whichway \
+	gcloud functions deploy point-hub \
 	  --gen2 \
 	  --project ${project} \
 	  --region asia-northeast1 \

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,7 @@
 .PHONY: init build dev lint
 
 GO111MODULE=on
-PROJECT=point-hub-496713
+PROJECT=whichway-494614
 
 init:
 	go mod download
@@ -25,7 +25,7 @@ deploy:
 	make __deploy project=${PROJECT}
 
 __deploy:
-	gcloud functions deploy point-hub \
+	gcloud functions deploy whichway \
 	  --gen2 \
 	  --project ${project} \
 	  --region asia-northeast1 \

--- a/api/app/external/yahoo_transit.go
+++ b/api/app/external/yahoo_transit.go
@@ -147,15 +147,31 @@ type SummaryInfo struct {
 }
 
 type EdgeInfo struct {
-	StationName                  string     `json:"stationName"`
-	RailName                     string     `json:"railName"`
-	RailNameExcludingDestination string     `json:"railNameExcludingDestination"`
-	Destination                  string     `json:"destination"`
-	State                        int        `json:"state"`
-	PointName                    string     `json:"pointName"`
-	TimeInfo                     []TimeInfo `json:"timeInfo"`
-	PriceInfo                    PriceInfo  `json:"priceInfo"`
+	StationName                  string              `json:"stationName"`
+	RailName                     string              `json:"railName"`
+	RailNameExcludingDestination string              `json:"railNameExcludingDestination"`
+	Destination                  string              `json:"destination"`
+	State                        int                 `json:"state"`
+	PointName                    string              `json:"pointName"`
+	TimeInfo                     []TimeInfo          `json:"timeInfo"`
+	PriceInfo                    PriceInfo           `json:"priceInfo"`
+	RidingPositionInfo           *RidingPositionInfo `json:"ridingPositionInfo"`
+	StopStationList              []StopStation       `json:"stopStationList"`
+	DiaInfoStatus                []DiaInfoStatus     `json:"diaInfoStatus"`
 }
+
+type RidingPositionInfo struct {
+	Departure []string `json:"departure"`
+	Arrival   []string `json:"arrival"`
+	Position  []string `json:"position"`
+}
+
+type StopStation struct {
+	Name          string `json:"name"`
+	DepartureTime string `json:"departureTime"`
+}
+
+type DiaInfoStatus map[string]any
 
 type TimeInfo struct {
 	Time string `json:"time"`

--- a/frontend/app/RouteCard.tsx
+++ b/frontend/app/RouteCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { UniqueRoute } from './types';
+import { RouteEdge, UniqueRoute } from './types';
 
 const InfoChip = ({ children, icon, color = "slate" }: { children: React.ReactNode, icon?: React.ReactNode, color?: string }) => {
   const colors: Record<string, string> = {
@@ -24,15 +24,25 @@ export default function RouteCard({ r, i }: { r: UniqueRoute, i: number }) {
 
   const edges = r.ScoredRoute.Route.edgeInfoList;
   
-  const isThroughService = (edge: any, idx: number) => {
+  const isThroughService = (edge: RouteEdge, idx: number) => {
     if (idx === 0 || idx === edges.length - 1) return false;
-    const arrTime = edge.timeInfo.find((t: any) => t.type === 2 || t.type === 4)?.time;
-    const depTime = edge.timeInfo.find((t: any) => t.type === 1 || t.type === 3)?.time;
+    const arrTime = edge.timeInfo.find((t) => t.type === 2 || t.type === 4)?.time;
+    const depTime = edge.timeInfo.find((t) => t.type === 1 || t.type === 3)?.time;
     return arrTime === depTime && arrTime !== undefined;
   };
 
   const significantEdges = edges.filter((edge, idx) => !isThroughService(edge, idx));
   const isDirect = r.ScoredRoute.Route.summaryInfo.transferCount === "0";
+
+  const getPlatform = (edge: RouteEdge, kind: 'departure' | 'arrival') =>
+    edge.ridingPositionInfo?.[kind]?.join('') || null;
+
+  const getDelayLabel = (edge: RouteEdge) => {
+    const status = edge.diaInfoStatus?.[0];
+    if (!status) return null;
+    const text = Object.values(status).find((value: unknown) => typeof value === 'string');
+    return text ? String(text) : '運行情報あり';
+  };
 
   return (
     <div className="group relative bg-white border border-slate-200/60 rounded-[1.8rem] sm:rounded-[2.5rem] shadow-[0_4px_20px_rgb(0,0,0,0.03)] hover:shadow-[0_15px_40px_rgb(0,0,0,0.08)] transition-all duration-500 ease-out overflow-hidden mb-4 mx-1">
@@ -126,7 +136,7 @@ export default function RouteCard({ r, i }: { r: UniqueRoute, i: number }) {
                         </p>
                         {edge.timeInfo && edge.timeInfo.length > 0 && (
                           <div className="flex gap-1.5 sm:gap-2 items-center overflow-x-auto no-scrollbar">
-                            {edge.timeInfo.map((ti: any, tIdx: number) => {
+                            {edge.timeInfo.map((ti, tIdx: number) => {
                               const label = ti.type === 1 || (ti.type === 3 && eIdx === 0) ? "発" : "着";
                               const colorClasses = label === "発" 
                                 ? "bg-emerald-50 text-emerald-700 border-emerald-100" 
@@ -142,6 +152,33 @@ export default function RouteCard({ r, i }: { r: UniqueRoute, i: number }) {
                         )}
                       </div>
                       
+                      {(getPlatform(edge, 'departure') || getPlatform(edge, 'arrival') || getDelayLabel(edge)) && (
+                        <div className="flex flex-wrap gap-2 mt-2">
+                          {getPlatform(edge, 'departure') && (
+                            <span className="px-2 py-1 rounded-lg bg-indigo-50 text-indigo-700 border border-indigo-100 text-[10px] font-black">
+                              {eIdx === 0 ? '出発' : '乗換'} {getPlatform(edge, 'departure')}
+                            </span>
+                          )}
+                          {eIdx > 0 && getPlatform(edge, 'arrival') && (
+                            <span className="px-2 py-1 rounded-lg bg-slate-50 text-slate-600 border border-slate-200 text-[10px] font-black">
+                              到着 {getPlatform(edge, 'arrival')}
+                            </span>
+                          )}
+                          {getDelayLabel(edge) && (
+                            <span className="px-2 py-1 rounded-lg bg-rose-50 text-rose-700 border border-rose-100 text-[10px] font-black">
+                              遅延: {getDelayLabel(edge)}
+                            </span>
+                          )}
+                        </div>
+                      )}
+
+                      {(edge.stopStationList ?? []).length > 0 && (
+                        <details className="mt-2 text-xs text-slate-500">
+                          <summary className="cursor-pointer font-bold">途中駅 {(edge.stopStationList ?? []).length}駅</summary>
+                          <p className="mt-1 leading-6">{(edge.stopStationList ?? []).map((stop) => `${stop.name} ${stop.departureTime}`).join(' · ')}</p>
+                        </details>
+                      )}
+
                       {eIdx < edges.length - 1 && (
                         <div className="mt-3 mb-4 sm:mt-4 sm:mb-6 relative">
                           <div className="px-3 py-1.5 sm:px-4 sm:py-2.5 rounded-xl sm:rounded-2xl bg-white border border-slate-100 shadow-sm inline-flex items-center gap-2 sm:gap-3 max-w-full overflow-hidden transition-all duration-300">

--- a/frontend/app/RouteList.tsx
+++ b/frontend/app/RouteList.tsx
@@ -1,4 +1,4 @@
-import RouteCard from './RouteCard';
+import RouteResults from './RouteResults';
 import { UniqueRoute, ApiResponse } from './types';
 
 interface Props {
@@ -8,66 +8,37 @@ interface Props {
   viaPatterns?: string | string[];
 }
 
-const toArray = (v: string | string[] | undefined): string[] => {
-  if (!v) return [];
-  return Array.isArray(v) ? v : [v];
-};
+const toArray = (value: string | string[] | undefined): string[] =>
+  value ? (Array.isArray(value) ? value : [value]) : [];
 
 export default async function RouteList({ from, to, preferredLines, viaPatterns }: Props) {
+  const preferredLineValues = toArray(preferredLines);
+  const viaPatternValues = toArray(viaPatterns);
   let routes: UniqueRoute[] = [];
   let error: string | null = null;
 
   try {
     const params = new URLSearchParams({ from, to });
-    toArray(preferredLines).forEach(v => params.append('preferred_lines', v));
-    toArray(viaPatterns).forEach(v => params.append('via_patterns', v));
-    const apiBase = process.env.API_BASE_URL;
-    const url = `${apiBase}/api/routes?${params.toString()}`;
-    const res = await fetch(url, { cache: 'no-store' });
-    if (!res.ok) throw new Error('Failed to fetch routes');
+    preferredLineValues.forEach((value) => params.append('preferred_lines', value));
+    viaPatternValues.forEach((value) => params.append('via_patterns', value));
+    const res = await fetch(`${process.env.API_BASE_URL}/api/routes?${params.toString()}`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) throw new Error('ルートの取得に失敗しました');
     const data: ApiResponse = await res.json();
-    routes = data.routes || [];
-  } catch (err) {
-    error = err instanceof Error ? err.message : 'Unknown error';
-  }
-
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center p-12 bg-rose-50/50 rounded-[2.5rem] border border-rose-100 shadow-sm w-full text-center gap-4">
-        <div className="w-16 h-16 rounded-full bg-rose-100 flex items-center justify-center text-rose-600">
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-          </svg>
-        </div>
-        <div className="flex flex-col gap-1">
-          <h3 className="text-xl font-black text-rose-900 tracking-tight">データの取得に失敗しました</h3>
-          <p className="text-sm text-rose-600 font-bold opacity-80">{error}</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (routes.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-20 bg-slate-50/50 rounded-[2.5rem] border border-slate-100 shadow-sm w-full gap-4">
-        <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center text-slate-400">
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9.172 9.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        </div>
-        <div className="flex flex-col gap-1 items-center">
-          <h3 className="text-xl font-black text-slate-900 tracking-tight">ルートが見つかりませんでした</h3>
-          <p className="text-sm text-slate-500 font-medium">条件を変えて再度お試しください</p>
-        </div>
-      </div>
-    );
+    routes = data.routes ?? [];
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : 'ルートの取得に失敗しました';
   }
 
   return (
-    <div className="flex flex-col gap-3 w-full pb-20">
-      {routes.slice(0, 10).map((r, i) => (
-        <RouteCard key={i} r={r} i={i} />
-      ))}
-    </div>
+    <RouteResults
+      routes={routes}
+      error={error}
+      from={from}
+      to={to}
+      preferredLines={preferredLineValues}
+      viaPatterns={viaPatternValues}
+    />
   );
 }

--- a/frontend/app/RouteResults.tsx
+++ b/frontend/app/RouteResults.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import RouteCard from './RouteCard';
+import { UniqueRoute } from './types';
+
+const CACHE_PREFIX = 'whichway_routes:';
+
+function cacheKey(from: string, to: string, preferredLines: string[], viaPatterns: string[]) {
+  return `${CACHE_PREFIX}${JSON.stringify({ from, to, preferredLines, viaPatterns })}`;
+}
+
+export default function RouteResults({
+  routes,
+  error,
+  from,
+  to,
+  preferredLines,
+  viaPatterns,
+}: {
+  routes: UniqueRoute[];
+  error: string | null;
+  from: string;
+  to: string;
+  preferredLines: string[];
+  viaPatterns: string[];
+}) {
+  const [displayRoutes, setDisplayRoutes] = useState(routes);
+  const [isCached, setIsCached] = useState(false);
+
+  useEffect(() => {
+    const key = cacheKey(from, to, preferredLines, viaPatterns);
+    try {
+      if (routes.length > 0) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setDisplayRoutes(routes);
+        setIsCached(false);
+        localStorage.setItem(key, JSON.stringify(routes));
+        return;
+      }
+      setDisplayRoutes([]);
+      const cached = localStorage.getItem(key);
+      if (cached) {
+        setDisplayRoutes(JSON.parse(cached) as UniqueRoute[]);
+        setIsCached(true);
+      }
+    } catch {
+      // localStorage が使えない環境では通常の結果表示を継続する
+    }
+  }, [from, to, preferredLines, viaPatterns, routes]);
+
+  if (displayRoutes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 bg-slate-50/50 rounded-[2.5rem] border border-slate-100 shadow-sm w-full gap-4">
+        <h3 className="text-xl font-black text-slate-900 tracking-tight">
+          {error ? 'ルートを取得できませんでした' : 'ルートが見つかりませんでした'}
+        </h3>
+        <p className="text-sm text-slate-500 font-medium">{error ?? '条件を変えて再度お試しください'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 w-full pb-20">
+      {isCached && <p className="text-xs font-bold text-amber-600 px-2">前回取得した検索結果を表示しています</p>}
+      {displayRoutes.slice(0, 10).map((route, index) => (
+        <RouteCard key={index} r={route} i={index} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/SearchForm.tsx
+++ b/frontend/app/SearchForm.tsx
@@ -12,6 +12,87 @@ interface TagInputProps {
   onRemove: (index: number) => void;
 }
 
+function StationInput({
+  id,
+  placeholder,
+  value,
+  onChange,
+  onKeyDown,
+}: {
+  id: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
+}) {
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; name: string; feedName?: string }>>([]);
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    const query = value.trim();
+    if (!query) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`https://api.transit.ls8h.com/api/v1/locations/suggest?q=${encodeURIComponent(query)}&limit=8`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const data = await res.json() as { stations?: Array<{ id: string; name: string; feedName?: string }> };
+        setSuggestions(data.stations ?? []);
+      } catch {
+        // 候補 API が利用できない場合も自由入力は利用できる
+      }
+    }, 250);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [value]);
+
+  return (
+    <div className="relative flex-1 min-w-0">
+      <input
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        value={value}
+        autoComplete="off"
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setTimeout(() => setIsFocused(false), 150)}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        className="w-full bg-transparent text-slate-800 font-semibold text-sm placeholder:text-slate-400 outline-none"
+      />
+      {isFocused && suggestions.length > 0 && (
+        <ul role="listbox" className="absolute z-30 left-0 right-0 top-full mt-2 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl">
+          {suggestions.map((station) => (
+            <li key={station.id}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-blue-50"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onChange(station.name);
+                  setSuggestions([]);
+                  setIsFocused(false);
+                }}
+              >
+                <span className="block text-sm font-bold text-slate-800">{station.name}</span>
+                {station.feedName && <span className="block text-xs text-slate-400">{station.feedName}</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function TagInput({ id, placeholder, tags, onAdd, onRemove }: TagInputProps) {
   const [input, setInput] = useState('');
   const [dupWarning, setDupWarning] = useState<string | null>(null);
@@ -116,8 +197,13 @@ export default function SearchForm() {
   useEffect(() => {
     const saved = loadFormValues();
     if (!saved) return;
-    if (!searchParams.get('from') && saved.from) setFrom(saved.from);
-    if (!searchParams.get('to') && saved.to) setTo(saved.to);
+    if (!searchParams.get('from') && saved.from) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setFrom(saved.from);
+    }
+    if (!searchParams.get('to') && saved.to) {
+      setTo(saved.to);
+    }
     if (!searchParams.getAll('preferred_lines').length && saved.preferredLines.length) {
       setPreferredLines(saved.preferredLines);
       setShowAdvanced(true);
@@ -159,15 +245,7 @@ export default function SearchForm() {
             <circle cx="12" cy="12" r="4" strokeWidth={2.5} />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 2v2m0 16v2M2 12h2m16 0h2" />
           </svg>
-          <input
-            id="from-station"
-            type="text"
-            placeholder="出発地"
-            value={from}
-            onChange={(e) => setFrom(e.target.value)}
-            onKeyDown={handleStationKeyDown}
-            className="flex-1 bg-transparent text-slate-800 font-semibold text-sm placeholder:text-slate-400 outline-none"
-          />
+          <StationInput id="from-station" placeholder="出発地" value={from} onChange={setFrom} onKeyDown={handleStationKeyDown} />
         </div>
 
         {/* 入れ替えボタン */}
@@ -209,15 +287,7 @@ export default function SearchForm() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <input
-            id="to-station"
-            type="text"
-            placeholder="目的地"
-            value={to}
-            onChange={(e) => setTo(e.target.value)}
-            onKeyDown={handleStationKeyDown}
-            className="flex-1 bg-transparent text-slate-800 font-semibold text-sm placeholder:text-slate-400 outline-none"
-          />
+          <StationInput id="to-station" placeholder="目的地" value={to} onChange={setTo} onKeyDown={handleStationKeyDown} />
         </div>
 
         {/* 検索ボタン */}

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -1,3 +1,12 @@
+export interface RouteEdge {
+  stationName: string;
+  railName: string;
+  timeInfo: Array<{ time: string; type: number }>;
+  ridingPositionInfo?: { departure?: string[]; arrival?: string[]; position?: string[] } | null;
+  stopStationList?: Array<{ name: string; departureTime: string }>;
+  diaInfoStatus?: Array<Record<string, string | number | boolean | null>>;
+}
+
 export interface UniqueRoute {
   ScoredRoute: {
     Score: number;
@@ -9,14 +18,7 @@ export interface UniqueRoute {
         totalPrice: string;
         transferCount: string;
       };
-      edgeInfoList: Array<{
-        stationName: string;
-        railName: string;
-        timeInfo: Array<{
-          time: string;
-          type: number;
-        }>;
-      }>;
+      edgeInfoList: RouteEdge[];
     };
     ViaPatterns: string[] | null;
   };


### PR DESCRIPTION
## 対応Issue

- Closes #1
- Closes #4
- Closes #5
- Closes #6

## 概要

- 駅名入力時の候補表示を追加
- 経路詳細に番線、途中駅、遅延情報を表示
- 検索結果を localStorage に保存し、取得失敗時に復元
- Yahoo Transit の応答モデルを拡張

## 設計上の判断

候補取得と localStorage 操作はブラウザ側で行い、既存の経路検索 API はサーバー側取得のまま維持しました。候補 API が利用できない場合も自由入力は継続できます。検索結果キャッシュは検索条件をキーにして別条件の結果が混ざらないようにしています。

## 検証

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `gofmt -w app/external/yahoo_transit.go`
- `go vet ./...`
- `go test ./...`
- `git diff --check`

## 既知の制約

- UI の実ブラウザ確認・スクリーンショットは未実施です。
- 候補 API は外部の公開読み取り専用 API に依存します。
