### PR TITLE
ci: GitHub Actions で CI/CD を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - ".github/workflows/ci.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api:
+    name: API
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: api/go.mod
+          cache: true
+          cache-dependency-path: api/go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11
+          working-directory: api
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  frontend:
+    name: Deploy frontend
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel --prod --yes --token="$VERCEL_TOKEN"
+
+  api:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to Google Cloud Functions
+        run: make deploy

--- a/api/app/external/yahoo_transit.go
+++ b/api/app/external/yahoo_transit.go
@@ -81,7 +81,9 @@ func fetchRoutesHTML(from string, to string, vias []string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("通信エラー: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/api/app/handler/route_handler.go
+++ b/api/app/handler/route_handler.go
@@ -45,7 +45,7 @@ func HandleRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 	if params.From == "" || params.To == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(ErrorResp{Error: "from と to クエリパラメータが必要です"})
+		_ = json.NewEncoder(w).Encode(ErrorResp{Error: "from と to クエリパラメータが必要です"})
 		return
 	}
 
@@ -53,9 +53,9 @@ func HandleRoutes(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Println("検索エラー:", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(ErrorResp{Error: "ルートの検索に失敗しました"})
+		_ = json.NewEncoder(w).Encode(ErrorResp{Error: "ルートの検索に失敗しました"})
 		return
 	}
 
-	json.NewEncoder(w).Encode(RouteResp{Routes: uniqueRoutes})
+	_ = json.NewEncoder(w).Encode(RouteResp{Routes: uniqueRoutes})
 }


### PR DESCRIPTION
Closes #8

## 概要
- Pull Request で frontend / api の品質検証を実行する CI workflow を追加
- main への push または手動実行で Vercel / Google Cloud Functions へデプロイする CD workflow を追加

## 設計判断
- 既存の `frontend/Makefile` と `api/Makefile` のデプロイ手順に合わせ、デプロイコマンド自体は変更していません。
- Go のバージョンは `api/go.mod` から取得し、frontend は Node.js 22 を使用します。
- Vercel の `VERCEL_TOKEN` と Google Cloud の `GCP_CREDENTIALS_JSON` は GitHub の `production` environment secrets から読み込みます。
- CI は `dev-platform` の GitHub Actions 例に合わせ、PR の変更パスに応じて実行します。

## Acceptance Criteria
- [x] Pull Request で frontend と api の検証が自動実行される
- [x] frontend の lint・type check・build を実行する
- [x] api の format check・vet・test・build を実行する
- [x] main push / 手動実行で既存のデプロイ手順を利用できる
- [x] 認証情報を GitHub Secrets からのみ読み込む

## 検証
- YAML 構文確認: PASS
- API: gofmt / go vet ./... / go test ./... / go build ./...: PASS
- frontend: npm ci / npm run lint / npx tsc --noEmit / npm run build: PASS
- git diff --check: PASS

## 既知の制約
- CD 実行前に `production` environment へ `VERCEL_TOKEN` と `GCP_CREDENTIALS_JSON` を登録する必要があります。
- `npm ci` で既存依存関係由来の audit 警告（7件）が出ましたが、依存関係は変更していません。
- main への push 後に GitHub Actions の CI/CD 結果を確認します。

## UI証跡
UI変更なし。

## レビュー知見の還元
今回の変更から dev-platform へ還元すべき新規知見はありません。
