### PR TITLE
fix: use whichway WIF configuration for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - "api/**"
       - "frontend/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/deploy.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,17 +59,17 @@ jobs:
 
       - name: Validate Google Cloud federation configuration
         env:
-          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          WIF_PROVIDER: projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway
+          SERVICE_ACCOUNT: github-actions-deployer@whichway-494614.iam.gserviceaccount.com
         run: |
-          test -n "$WIF_PROVIDER" || { echo "GCP_WORKLOAD_IDENTITY_PROVIDER is not configured in the production environment."; exit 1; }
-          test -n "$SERVICE_ACCOUNT" || { echo "GCP_SERVICE_ACCOUNT is not configured in the production environment."; exit 1; }
+          test -n "$WIF_PROVIDER"
+          test -n "$SERVICE_ACCOUNT"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway
+          service_account: github-actions-deployer@whichway-494614.iam.gserviceaccount.com
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3


### PR DESCRIPTION
Closes #12

## 概要
- GCP 側に作成した `whichway-494614` の WIF Provider を workflow に反映
- 専用 Service Account `github-actions-deployer@whichway-494614.iam.gserviceaccount.com` を使用
- GitHub Variables / Secrets に GCP 認証情報を登録不要に変更
- CI / CD action を Node 24 対応版へ更新済み

## GCP 設定
- Provider: `projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway`
- Repository 条件: `assertion.repository == 'kikudesuyo/whichway'`
- IAM: Cloud Functions Developer、実行用 App Engine SA への Service Account User、WIF User

## 検証
- gcloud で Provider が ACTIVE であることを確認
- YAML 構文確認: PASS
- git diff --check: PASS
- CI: GitHub Actions で確認中

## UI証跡
UI変更なし。
