### PR TITLE
fix: make CD resilient to missing deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  frontend-config:
+    name: Check frontend deployment configuration
+    runs-on: ubuntu-latest
+    environment: production
+    outputs:
+      enabled: ${{ steps.config.outputs.enabled }}
+    steps:
+      - id: config
+        name: Check Vercel token
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -n "$VERCEL_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "VERCEL_TOKEN is not configured; skipping frontend deployment."
+          fi
+
   frontend:
     name: Deploy frontend
+    needs: frontend-config
+    if: needs.frontend-config.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     environment: production
     defaults:


### PR DESCRIPTION
Closes #14

## 概要
- GCP 側の不足 IAM を設定済み（Compute SA への actAs、Cloud Build Builder）
- Vercel token 未設定時は Frontend deploy を明示的に skip
- API deploy は WIF で継続実行

## 検証
- Cloud Resource Manager API enabled
- GCP IAM bindings verified
- YAML / git diff --check: 実行予定
- GitHub Actions CI / Deploy: 実行予定

## 制約
Vercel token が未設定のため、Frontend deploy は skip されます。Vercel も自動デプロイする場合は、既存の承認済み運用で token を設定してください。
