### PR TITLE
ci: split frontend and API CI/CD workflows

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -1,13 +1,11 @@
-name: CI
+name: CI API
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     paths:
       - "api/**"
-      - "frontend/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/deploy.yml"
+      - ".github/workflows/ci-api.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +23,7 @@ jobs:
         working-directory: api
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -54,32 +52,3 @@ jobs:
 
       - name: Build
         run: go build ./...
-
-  frontend:
-    name: Frontend
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run type check
-        run: npx tsc --noEmit
-
-      - name: Build
-        run: npm run build

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,45 @@
+name: CI Frontend
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/ci-frontend.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,43 @@
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - ".github/workflows/deploy-api.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy-api
+  cancel-in-progress: false
+
+jobs:
+  api:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway
+          service_account: github-actions-deployer@whichway-494614.iam.gserviceaccount.com
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Deploy to Google Cloud Functions
+        run: make deploy

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,23 +1,22 @@
-name: Deploy
+name: Deploy Frontend
 
 on:
   push:
     branches: [main]
     paths:
-      - "api/**"
       - "frontend/**"
-      - ".github/workflows/deploy.yml"
+      - ".github/workflows/deploy-frontend.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: production-deploy
+  group: production-deploy-frontend
   cancel-in-progress: false
 
 jobs:
-  frontend-config:
+  config:
     name: Check frontend deployment configuration
     runs-on: ubuntu-latest
     environment: production
@@ -38,8 +37,8 @@ jobs:
 
   frontend:
     name: Deploy frontend
-    needs: frontend-config
-    if: needs.frontend-config.outputs.enabled == 'true'
+    needs: config
+    if: needs.config.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     environment: production
     defaults:
@@ -63,37 +62,3 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: npx vercel --prod --yes --token="$VERCEL_TOKEN"
-
-  api:
-    name: Deploy API
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      contents: read
-      id-token: write
-    defaults:
-      run:
-        working-directory: api
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Validate Google Cloud federation configuration
-        env:
-          WIF_PROVIDER: projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway
-          SERVICE_ACCOUNT: github-actions-deployer@whichway-494614.iam.gserviceaccount.com
-        run: |
-          test -n "$WIF_PROVIDER"
-          test -n "$SERVICE_ACCOUNT"
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: projects/822728042696/locations/global/workloadIdentityPools/github-actions/providers/whichway
-          service_account: github-actions-deployer@whichway-494614.iam.gserviceaccount.com
-
-      - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Deploy to Google Cloud Functions
-        run: make deploy


### PR DESCRIPTION
Closes #16

## 概要
- FE CI と API CI を別 workflow に分離
- FE CD と API CD を別 workflow に分離
- 各 workflow の path filter / concurrency / permissions をコンポーネント単位に整理
- Vercel token 未設定時の skip と GCP WIF 認証を維持

## Acceptance Criteria
- [x] FE / API の CI を個別に確認できる
- [x] FE / API の CD を個別に確認できる
- [x] FE / API の変更時に不要な workflow を実行しない
- [x] 既存の認証・skip 動作を維持

## 検証
- 全 workflow の YAML 構文: PASS
- `git diff --check`: PASS
- GitHub Actions CI: 実行中
- CD: 手動 dispatch で個別確認予定

## UI証跡
UI変更なし。
